### PR TITLE
Change clone command to use https & immediately npm install.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ Note the Client ID and Client Secret (under the `Credentials` tab), as you'll ne
 
 ## Local Install
 
-Clone the repo, install dependencies and run Cypress tests
+Clone the repo, install dependencies and run Cypress tests by copying and pasting these lines:
 
 ```bash
-git clone git@github.com:garywong-bc/invasives-e2e-demo.git && cd invasives-e2e-demo
-npm install
+git clone https://github.com/garywong-bc/invasives-e2e-demo.git \
+&& cd invasives-e2e-demo \
+&& npm install
 ```
 
 ### Application Setup


### PR DESCRIPTION
Some machines (like mine) seem to like https git clone commands, (same with range repos for our vendor on their machines).  Made that small change to the clone command and made sure `npm install` runs right away.